### PR TITLE
dpy: use fstrings

### DIFF
--- a/python/discordpy-async/Example-NoShards.py
+++ b/python/discordpy-async/Example-NoShards.py
@@ -20,15 +20,15 @@ class DiscordBotsOrgAPI:
             'Content-type' : 'application/json'
         }
 
-        url = '{}/bots/{}/stats'.format('https://discordbots.org/api', self.bot.user.id)
+        url = 'https://discordbots.org/api/bots/{self.bot.user.id}/stats'
 
         async with self.session.post(url, data=payload, headers=head) as req:
             if req.status == 200:
                 logging.info('poster[dbl]: done')
             else:
                 t = await req.text()
-                logging.error('poster[dbl]: failed (code {})'.format(req.status))
-                logging.error('poster[dbl]: response: {}'.format(t))
+                logging.error(f'poster[dbl]: failed (code {req.status})')
+                logging.error(f'poster[dbl]: response: {t}')
         
     async def on_server_join(self, server):
         await self.update()

--- a/python/discordpy-async/Example-Shards.py
+++ b/python/discordpy-async/Example-Shards.py
@@ -22,7 +22,7 @@ class DiscordBotsOrgAPI:
             'Content-type' : 'application/json'
         }
 
-        url = f'https://discordbots.org/bots/{self.bot.user.id}/stats'
+        url = f'https://discordbots.org/api/bots/{self.bot.user.id}/stats'
 
         async with self.session.post(url, data=payload, headers=head) as req:
             if req.status == 200:

--- a/python/discordpy-async/Example-Shards.py
+++ b/python/discordpy-async/Example-Shards.py
@@ -22,15 +22,15 @@ class DiscordBotsOrgAPI:
             'Content-type' : 'application/json'
         }
 
-        url = '{}/bots/{}/stats'.format('https://discordbots.org/api', self.bot.user.id)
+        url = f'https://discordbots.org/bots/{self.bot.user.id}/stats'
 
         async with self.session.post(url, data=payload, headers=head) as req:
             if req.status == 200:
                 logging.info('poster[dbl]: done')
             else:
                 t = await req.text()
-                logging.error('poster[dbl]: failed (code {})'.format(req.status))
-                logging.error('poster[dbl]: response: {}'.format(t))
+                logging.error(f'poster[dbl]: failed (code {req.status})')
+                logging.error(f'poster[dbl]: response: {t}')
         
     async def on_server_join(self, server):
         await self.update()

--- a/python/discordpy-rewrite/Example-NoShards.py
+++ b/python/discordpy-rewrite/Example-NoShards.py
@@ -17,18 +17,18 @@ class DiscordBotsOrgAPI:
         })
         head = {
             'Authorization': self.key,
-            'Content-type' : 'application/json'
+            'Content-type': 'application/json'
         }
 
-        url = '{}/bots/{}/stats'.format('https://discordbots.org/api', self.bot.user.id)
+        url = f'https://discordbots.org/api/bots/{self.bot.user.id}/stats'
 
         async with self.session.post(url, data=payload, headers=head) as req:
             if req.status == 200:
                 logging.info('poster[dbl]: done')
             else:
                 t = await req.text()
-                logging.error('poster[dbl]: failed (code {})'.format(req.status))
-                logging.error('poster[dbl]: response: {}'.format(t))
+                logging.error(f'poster[dbl]: failed (code {req.status})')
+                logging.error(f'poster[dbl]: response: {t}')
         
     async def on_guild_join(self, guild):
         await self.update()

--- a/python/discordpy-rewrite/Example-Shards.py
+++ b/python/discordpy-rewrite/Example-Shards.py
@@ -22,15 +22,15 @@ class DiscordBotsOrgAPI:
             'Content-type' : 'application/json'
         }
 
-        url = '{}/bots/{}/stats'.format('https://discordbots.org/api', self.bot.user.id)
+        url = f'https://discordbots.org/api/bots/{self.bot.user.id}/stats'
 
         async with self.session.post(url, data=payload, headers=head) as req:
             if req.status == 200:
                 logging.info('poster[dbl]: done')
             else:
                 t = await req.text()
-                logging.error('poster[dbl]: failed (code {})'.format(req.status))
-                logging.error('poster[dbl]: response: {}'.format(t))
+                logging.error(f'poster[dbl]: failed (code {req.status})')
+                logging.error('poster[dbl]: response: {t}')
         
     async def on_guild_join(self, guild):
         await self.update()


### PR DESCRIPTION
This PR replaces format calls with f strings, introduced in Python 3.6 (by PEP 0498). Most Python bot developers should have a recent Python version (3.6.0 or higher) installed so this shouldn't affect much.