### PR TITLE
fix: Correct documentation for dblposter

### DIFF
--- a/javascript/Example-All.js
+++ b/javascript/Example-All.js
@@ -9,7 +9,7 @@ const dblposter = require("dblposter");
  * After this, you are able to access this instance anywhere with <client>.dblPoster
  * or whatever value you chose when binding the poster to your client.
  */
-const dbl = new dblposter(client, "DBLAPIKEY");
+const dbl = new dblposter("DBLAPIKEY", client);
 
 // Binds the client to the internal timer
 // You can also pass in a custom name for the value that will get bound to the client.


### PR DESCRIPTION
I wrote the documentation wrong on the `new dblposter` part, as the order is key,client not client,key.

This PR fixes that 